### PR TITLE
Add directory output format; other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 A downloader for TailwindPlus components in HTML, React, and Vue formats across Tailwind CSS v3 and
 v4 in system, light, and dark modes; and a diff tool to compare components between downloads.
 
-TailwindPlus components are downloaded into a structured JSON file, preserving the component
-organization.
+TailwindPlus components are downloaded into a structured JSON file or a directory tree of individual
+files, preserving the component organization.
 
 The JSON file can be used with the [TailwindPlus MCP
-server](https://github.com/richardkmichael/mcp-tailwindplus), or directly with `jq`. See below for
-more.
+server](https://github.com/richardkmichael/mcp-tailwindplus), or directly with `jq`. The directory
+output allows an agent to naturally discover and read components using regular CLI tooling. See below
+for more.
 
 The diff tool is helpful because TailwindPlus undergoes small fixes, for which there is no changelog.
 
@@ -46,11 +47,14 @@ echo '{"email": "your-email@example.com", "password": "your-password"}' > .tailw
 ## Features
 
 - Downloads all UI components in HTML, React, and Vue frameworks for both Tailwind CSS v3 and v4 in
-  system, light, and dark modes into a JSON file, preserving the hierarchical organization
+  system, light, and dark modes, preserving the hierarchical organization
     - Note: eCommerce components do not have modes
+- Two output formats: a single JSON file (`--output-format=json`, default) or a directory tree of
+  individual component files (`--output-format=dir`)
 - Defaults to a 15 worker pool with retries for fast, reliable downloads, adjust with `--workers N`
-- Timestamped output files allow comparing component versions between downloads
+- Timestamped output names allow comparing component versions between downloads
 - Handles authentication via stored credentials or interactive prompts with session persistence
+- Prompts before overwriting existing output; use `--overwrite` to skip the prompt in scripts
 
 ## Using TailwindPlus with an agent
 
@@ -94,6 +98,36 @@ Then ask for a component:
   - Great for power users
 
   For a header, I'd recommend the first one with a search icon - it's the most recognizable and space-efficient.
+```
+
+### Directory output
+
+Use `--output-format=dir` to write each component snippet as an individual file in a directory tree.
+An agent can then discover and selectively read components using regular CLI tooling (`ls`, `cat`,
+etc.) without loading the entire ~6 MB JSON file into context.
+
+```bash
+npx github:richardkmichael/tailwindplus-downloader#latest --output-format=dir
+```
+
+The directory structure mirrors the component hierarchy:
+
+```
+tailwindplus-components-[TIMESTAMP]/
+├── metadata.json
+└── Marketing/
+    └── Page Sections/
+        └── Hero Sections/
+            └── Simple centered/
+                ├── v3/
+                │   ├── html-light.html
+                │   ├── html-dark.html
+                │   ├── html-system.html
+                │   ├── react-light.jsx
+                │   └── ...
+                └── v4/
+                    ├── html-light.html
+                    └── ...
 ```
 
 ### Directly use the JSON data file
@@ -145,6 +179,15 @@ npx github:richardkmichael/tailwindplus-downloader#latest
 
 # Custom output file
 npx github:richardkmichael/tailwindplus-downloader#latest --output ./my-components.json
+
+# Directory output (default name: tailwindplus-components-[TIMESTAMP]/)
+npx github:richardkmichael/tailwindplus-downloader#latest --output-format=dir
+
+# Directory output to a specific path
+npx github:richardkmichael/tailwindplus-downloader#latest --output-format=dir --output=./components
+
+# Overwrite existing output without prompting (useful in scripts with a fixed --output path)
+npx github:richardkmichael/tailwindplus-downloader#latest --output=./components --output-format=dir --overwrite
 
 # Custom credentials file
 npx github:richardkmichael/tailwindplus-downloader#latest --credentials ./my-credentials.json

--- a/README.md
+++ b/README.md
@@ -141,24 +141,12 @@ The skeleton file provides the LLM with the structure of the JSON file, allowing
   * use `jq` to query the full JSON file for the code for a _specific_ component
   * _search_ component _names_ to make component suggestions
 
-Generate the skeleton file with `jq`:
+Create the skeleton file:
 
 ```bash
-jq '
-def walk:
-  . as $in |
-    if type == "object" then
-      reduce keys[] as $key ({}; . + {($key): ($in[$key] | walk)})
-    elif type == "array" then
-      map(walk)
-    elif type == "string" then
-      if length > 100 then "<CONTENT>" else . end
-    else .
-    end;
-
-# Keep metadata, replace large string content in .tailwindplus
-. + {"tailwindplus": (.tailwindplus | walk)}
-' tailwindplus-components-*.json > tailwindplus-skeleton.json
+npm run create-skeleton
+npm run create-skeleton -- myfile.json   # pass a specific file (note: -- is required by npm)
+# or directly: scripts/create-skeleton.sh [--help] [FILE]
 ```
 
 Add only the skeleton file as context to a coding session or project. Then provide the LLM access to

--- a/README.md
+++ b/README.md
@@ -100,6 +100,25 @@ Then ask for a component:
   For a header, I'd recommend the first one with a search icon - it's the most recognizable and space-efficient.
 ```
 
+### Agent skill
+
+A skill is provided in `contrib/tailwind-plus/` to allow the agent to automatically browse and read
+components from the directory output when asked to build UI.
+
+Install it by symlinking into a skills directory.
+
+Global:
+
+```bash
+ln -s /path/to/tailwindplus-downloader/contrib/tailwind-plus ~/.claude/skills/tailwind-plus
+```
+
+Project:
+
+```bash
+ln -s /path/to/tailwindplus-downloader/contrib/tailwind-plus .claude/skills/tailwind-plus
+```
+
 ### Directory output
 
 Use `--output-format=dir` to write each component snippet as an individual file in a directory tree.

--- a/contrib/tailwind-plus/SKILL.md
+++ b/contrib/tailwind-plus/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: tailwind-plus
+description: >
+  This skill should be used when the user asks to "add a component", "use a
+  Tailwind Plus component", "build a UI", "create a form", "add a modal", "add
+  a sidebar", "create a landing page", or needs any UI component from Tailwind
+  Plus (formerly Tailwind UI). Use this when building pages, layouts, or UI
+  elements with Tailwind CSS.
+allowed-tools: Glob, Read, Bash(jq *)
+---
+
+# Tailwind Plus Components
+
+## Detect format and load workflow
+
+Use `Glob` to detect which format is available:
+
+- Directory format: `tailwindplus-components-????-??-??-??????/metadata.json`
+- JSON format: `tailwindplus-components-????-??-??-??????.json`
+
+Either may use a custom name if `--output` was specified during download.
+
+Then `Read` the appropriate workflow file from the same directory as this SKILL.md:
+
+- Directory format → `instructions-dir.md`
+- JSON format → `instructions-json.md`
+
+## Component catalog
+
+### Application UI
+- **Application Shells**: Multi-Column Layouts, Sidebar Layouts, Stacked Layouts
+- **Data Display**: Calendars, Description Lists, Stats
+- **Elements**: Avatars, Badges, Button Groups, Buttons, Dropdowns
+- **Feedback**: Alerts, Empty States
+- **Forms**: Action Panels, Checkboxes, Comboboxes, Form Layouts, Input Groups, Radio Groups, Select Menus, Sign-in and Registration, Textareas, Toggles
+- **Headings**: Card Headings, Page Headings, Section Headings
+- **Layout**: Cards, Containers, Dividers, List containers, Media Objects
+- **Lists**: Feeds, Grid Lists, Stacked Lists, Tables
+- **Navigation**: Breadcrumbs, Command Palettes, Navbars, Pagination, Progress Bars, Sidebar Navigation, Tabs, Vertical Navigation
+- **Overlays**: Drawers, Modal Dialogs, Notifications
+- **Page Examples**: Detail Screens, Home Screens, Settings Screens
+
+### Ecommerce
+- **Components**: Category Filters, Category Previews, Checkout Forms, Incentives, Order History, Order Summaries, Product Features, Product Lists, Product Overviews, Product Quickviews, Promo Sections, Reviews, Shopping Carts, Store Navigation
+- **Page Examples**: Category Pages, Checkout Pages, Order Detail Pages, Order History Pages, Product Pages, Shopping Cart Pages, Storefront Pages
+
+### Marketing
+- **Elements**: Banners, Flyout Menus, Headers
+- **Feedback**: 404 Pages
+- **Page Examples**: About Pages, Landing Pages, Pricing Pages
+- **Page Sections**: Bento Grids, Blog Sections, CTA Sections, Contact Sections, Content Sections, FAQs, Feature Sections, Footers, Header Sections, Hero Sections, Logo Clouds, Newsletter Sections, Pricing Sections, Stats, Team Sections, Testimonials

--- a/contrib/tailwind-plus/instructions-dir.md
+++ b/contrib/tailwind-plus/instructions-dir.md
@@ -1,0 +1,40 @@
+# Directory format workflow
+
+## Directory layout
+
+```
+{components-root}/
+  {Category}/
+    {Subcategory}/
+      {Group}/
+        {Component}/
+          v3/
+            html-system.html    ← HTML with light+dark mode support
+            html-light.html     ← HTML light only
+            html-dark.html      ← HTML dark only
+            react-system.jsx    ← React with light+dark mode support
+            react-light.jsx
+            react-dark.jsx
+            vue-system.vue
+            vue-light.vue
+            vue-dark.vue
+          v4/
+            html-system.html
+            ...
+```
+
+The components root directory name depends on how the downloader was invoked: the default is a
+timestamped directory (`tailwindplus-components-[TIMESTAMP]/`), but `--output` overrides it.
+
+## Steps
+
+1. Consult the component catalog in SKILL.md to identify the right group.
+2. Browse available components within the group: `Glob` `{components-root}/{Category}/{Subcategory}/{Group}/*/`
+3. List file variants for the chosen component: `Glob` `{components-root}/{Category}/{Subcategory}/{Group}/{Component}/v4/*`
+   Prefer `v4`; use `v3` only if the project targets Tailwind CSS v3.
+4. `Read` the appropriate file — choose to match the project's framework and dark mode approach
+   (`system` supports both light and dark via `dark:` prefixes). If either is unclear, ask the user.
+5. Adapt the code to the user's needs (replace placeholder text, adjust colors, wire up interactivity).
+
+Note: category, subcategory, group, and component names all contain spaces — account for this in
+Glob patterns.

--- a/contrib/tailwind-plus/instructions-json.md
+++ b/contrib/tailwind-plus/instructions-json.md
@@ -1,0 +1,16 @@
+# JSON file format workflow
+
+## Steps
+
+1. Consult the component catalog in SKILL.md to identify the right component.
+2. If `tailwindplus-skeleton.json` exists, `Read` it to confirm the component path before querying.
+3. Extract the component code with `jq`. Select by framework (`.name`), mode (`.mode`), and Tailwind
+   version (`.version`). Property names containing spaces must be quoted in the jq path:
+   ```
+   jq '.tailwindplus."{Category}"."{Subcategory}"."{Group}"."{Component}".snippets[]
+     | select(.name == "html" and .mode == "system" and .version == 4)
+     | .code' --raw-output tailwindplus-components-*.json
+   ```
+   Framework values: `html`, `react`, `vue`. Mode values: `system`, `light`, `dark`.
+   Prefer `system` and version `4`; adjust to match the project or ask the user if unclear.
+4. Adapt the code to the user's needs (replace placeholder text, adjust colors, wire up interactivity).

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
         "@eslint/js": "^9.27.0",
         "eslint": "^9.27.0",
         "globals": "^17.1.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "postinstall": "npx playwright install --with-deps chromium",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint --config eslint.config.cjs \"**/*.js\"",
-    "lint:fix": "eslint --config eslint.config.cjs \"**/*.js\" --fix"
+    "lint:fix": "eslint --config eslint.config.cjs \"**/*.js\" --fix",
+    "create-skeleton": "bash scripts/create-skeleton.sh"
   }
 }

--- a/scripts/create-skeleton.sh
+++ b/scripts/create-skeleton.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [FILE]"
+  echo ""
+  echo "Create a skeleton JSON file from a TailwindPlus components JSON file,"
+  echo "replacing component code with '<CONTENT>' placeholders."
+  echo ""
+  echo "Arguments:"
+  echo "  FILE    Path to the components JSON file."
+  echo "          Defaults to tailwindplus-components-YYYY-MM-DD-HHMMSS.json"
+  echo "          in the current directory."
+  echo ""
+  echo "Output: tailwindplus-skeleton.json"
+}
+
+if (( $# > 0 )) && [[ "$1" == "--help" || "$1" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ -e tailwindplus-skeleton.json ]]; then
+  echo "error: tailwindplus-skeleton.json already exists" >&2
+  exit 1
+fi
+
+if (( $# > 0 )); then
+  inputs=("$1")
+else
+  shopt -s nullglob
+  inputs=(tailwindplus-components-????-??-??-??????.json)
+  shopt -u nullglob
+  if (( ${#inputs[@]} == 0 )); then
+    echo "error: no tailwindplus components file found" >&2
+    exit 1
+  fi
+fi
+
+jq '
+def walk:
+  . as $in |
+    if type == "object" then
+      reduce keys[] as $key ({}; . + {($key): ($in[$key] | walk)})
+    elif type == "array" then
+      map(walk)
+    elif type == "string" then
+      if length > 100 then "<CONTENT>" else . end
+    else .
+    end;
+
+# Keep metadata, replace large string content in .tailwindplus
+. + {"tailwindplus": (.tailwindplus | walk)}
+' "${inputs[@]}" > tailwindplus-skeleton.json

--- a/tailwindplus-downloader.js
+++ b/tailwindplus-downloader.js
@@ -385,7 +385,11 @@ class TailwindPlusDownloader {
         this.componentData.Ecommerce = this._processEcommerceComponents(this.componentData.Ecommerce);
       }
 
-      this._processResultsAndWriteOutput();
+      if (this.options.outputFormat === 'dir') {
+        this._processResultsAndWriteDirectory();
+      } else {
+        this._processResultsAndWriteOutput();
+      }
     } catch (error) {
       if (error instanceof DownloaderError) {
         this.logger.error(error.message);
@@ -1249,20 +1253,70 @@ class TailwindPlusDownloader {
     fs.writeFileSync(outputFile, JSON.stringify(outputData, sortedObjects, 2));
   }
 
+  _processResultsAndWriteDirectory() {
+    const outputDir = this.options.output;
+
+    const endTime = new Date();
+    const durationMs = endTime - this.startTime;
+    const durationSec = (durationMs / 1000).toFixed(1);
+
+    const componentCount = this._countComponents(this.componentData);
+
+    // Sort snippets arrays for stable output
+    this.logger.debug('Sorting component data for stable output');
+    sortSnippetsRecursively(this.componentData);
+
+    this.logger.debug(`Writing component directory: ${outputDir}`);
+    fs.rmSync(outputDir, { recursive: true, force: true });
+    fs.mkdirSync(outputDir);
+
+    this._writeComponentFiles(outputDir, this.componentData, []);
+
+    const metadata = {
+      component_count: componentCount,
+      download_duration: `${durationSec}s`,
+      downloaded_at: this.startTime.toISOString(),
+      downloader_version: packageJson.version,
+      version: this.version,
+    };
+    fs.writeFileSync(path.join(outputDir, 'metadata.json'), JSON.stringify(metadata, sortedObjects, 2));
+  }
+
+  _writeComponentFiles(outputDir, data, pathParts) {
+    for (const [key, value] of Object.entries(data)) {
+      if (!value || typeof value !== 'object') continue;
+      if (value.snippets && Array.isArray(value.snippets)) {
+        for (const snippet of value.snippets) {
+          const ext = snippet.name === 'react' ? 'jsx' : snippet.name === 'vue' ? 'vue' : 'html';
+          const modePart = snippet.mode ? `-${snippet.mode}` : '';
+          const filename = `${snippet.name}${modePart}.${ext}`;
+          const versionDir = `v${snippet.version}`;
+          const snippetDir = path.join(outputDir, ...pathParts, key, versionDir);
+          fs.mkdirSync(snippetDir, { recursive: true });
+          fs.writeFileSync(path.join(snippetDir, filename), snippet.code);
+        }
+      } else {
+        this._writeComponentFiles(outputDir, value, [...pathParts, key]);
+      }
+    }
+  }
+
   _showStopMessage() {
     const endTime = new Date();
     const durationMs = endTime - this.startTime;
     const durationSec = (durationMs / 1000).toFixed(1);
 
     if (fs.existsSync(this.options.output)) {
-      const stats = fs.statSync(this.options.output);
-      const sizeKB = Math.round(stats.size / 1024);
-
-      const componentCount = this._countComponents(this.componentData);
+      const savedMessage = this.options.outputFormat === 'dir'
+        ? `Download complete! Components saved to directory ${this.options.output}`
+        : (() => {
+          const sizeKB = Math.round(fs.statSync(this.options.output).size / 1024);
+          return `Download complete! Components saved to ${this.options.output} (${sizeKB} KB)`;
+        })();
 
       const messageLines = [
         `Discovered ${this.urlCount} URLs with ${this.componentCount} individual components.`,
-        `Download complete! Components saved to ${this.options.output} (${sizeKB} KB)`,
+        savedMessage,
         `Duration: ${durationSec}s`
       ];
 
@@ -1698,7 +1752,7 @@ function parseArgs() {
     .option('output', {
       type: 'string',
       requiresArg: true,
-      describe: `Path to save downloaded components (default: ${CONFIG.outputBase}-[TIMESTAMP].json)`
+      describe: `Path to save downloaded components. For --output-format=json (default): ${CONFIG.outputBase}-[TIMESTAMP].json. For --output-format=dir: ${CONFIG.outputBase}-[TIMESTAMP]/`
     })
     .option('workers', {
       type: 'number',
@@ -1748,6 +1802,11 @@ function parseArgs() {
       default: false,
       describe: 'Download only free (unauthenticated) components without login'
     })
+    .option('output-format', {
+      choices: ['json', 'dir'],
+      default: 'json',
+      describe: 'Output format: json (single file) or dir (directory tree of individual component files)'
+    })
     .check((argv) => {
       // Validate workers bounds
       if (argv.workers <= 0) {
@@ -1763,6 +1822,7 @@ function parseArgs() {
     })
     .usage('Usage: $0 [options]')
     .example('$0 --output=components.json', 'Download to specific file')
+    .example('$0 --output-format=dir --output=components/', 'Write components as a directory tree')
     .example('$0 --workers=5 --debug', 'Slower download with debug logging')
     .epilog('Options can be specified as --option=value or --option value')
     .help('help')
@@ -1770,7 +1830,8 @@ function parseArgs() {
     .parseSync();
 
   return {
-    output: argv.output || CONFIG.output,
+    output: argv.output,
+    outputFormat: argv.outputFormat,
     workers: argv.workers,
     cookies: argv.cookies,
     session: argv.session || CONFIG.session,
@@ -1787,6 +1848,13 @@ function parseArgs() {
 
 async function main() {
   const options = parseArgs();
+
+  // Derive output path default based on format when not explicitly specified
+  if (!options.output) {
+    options.output = options.outputFormat === 'dir'
+      ? `${CONFIG.outputBase}-${CONFIG.version}`
+      : CONFIG.output;
+  }
 
   // Derive log filename if --log is used as a flag
   if (options.log === true) {

--- a/tailwindplus-downloader.js
+++ b/tailwindplus-downloader.js
@@ -552,6 +552,9 @@ class TailwindPlusDownloader {
       if (result === 'bad_credentials') {
         this.logger.error('Login failed, bad credentials.');
 
+        if (!process.stdin.isTTY) {
+          throw new DownloaderError('Login failed: bad credentials. Cannot prompt for new credentials in non-interactive mode.');
+        }
         const answer = await read({ prompt: 'Try again with new credentials? [Y/n]: ' });
         if (answer.toLowerCase() === 'n' || answer.toLowerCase() === 'no') {
           throw new DownloaderError('User aborted after failed login attempt.');
@@ -583,6 +586,11 @@ class TailwindPlusDownloader {
   async _obtainCredentials() {
     let credentials = this._tryLoadCredentials(this.credentials);
     if (!credentials) {
+      if (!process.stdin.isTTY) {
+        throw new DownloaderError(
+          `No credentials found. Provide a credentials file (${this.credentials}) or run interactively.`
+        );
+      }
       credentials = await this._promptCredentials();
     }
 
@@ -748,6 +756,8 @@ class TailwindPlusDownloader {
   }
 
   async _trySaveCredentials(credentials) {
+    if (!process.stdin.isTTY) return;
+
     const save = await read({ prompt: `\nSave credentials to file '${this.credentials}'? (WARNING: Security risk) [y/N]: ` });
     if (save.toLowerCase().startsWith('y')) {
       const { email, password } = credentials;

--- a/tailwindplus-downloader.js
+++ b/tailwindplus-downloader.js
@@ -361,6 +361,7 @@ class TailwindPlusDownloader {
 
   async start() {
     try {
+      await this._checkOutputExists();
       await this._initializeBrowser();
 
       const discovery = await this._discoverUrls();
@@ -707,6 +708,43 @@ class TailwindPlusDownloader {
     const email = await read({ prompt: 'Email: ' });
     const password = await read({ prompt: 'Password: ', silent: true, replace: '*' });
     return { email: email.trim(), password: password.trim(), source: 'prompt' };
+  }
+
+  async _checkOutputExists() {
+    const output = this.options.output;
+    const isDir = this.options.outputFormat === 'dir';
+    const kind = isDir ? 'directory' : 'file';
+
+    if (!fs.existsSync(output)) return;
+
+    // For directories, only warn if non-empty (empty dir has no data to lose)
+    if (isDir && fs.readdirSync(output).length === 0) return;
+
+    if (this.options.overwrite) {
+      process.stderr.write(`Output ${kind} exists: ${output} — overwriting.\n`);
+      this.logger.warn(`Output ${kind} exists: ${output} — overwriting.`);
+    } else {
+      // Non-interactive stdin (piped/CI): abort rather than hang
+      if (!process.stdin.isTTY) {
+        throw new DownloaderError(
+          `Output ${kind} already exists: ${output}. Use --overwrite to overwrite.`
+        );
+      }
+
+      process.stderr.write(`\nOutput ${kind} exists: ${output}\n`);
+      process.stderr.write('Overwrite?  Will result in data loss.\n');
+      const answer = await read({ prompt: '> NO/yes  (type `yes`): ' });
+      if (answer.trim() !== 'yes') {
+        throw new DownloaderError('Aborted.');
+      }
+      this.logger.warn(`Output ${kind} exists: ${output} — overwriting.`);
+    }
+
+    // For directories: delete before recreating to eliminate stale orphan files.
+    // JSON writeFileSync already replaces atomically, no pre-deletion needed.
+    if (isDir) {
+      fs.rmSync(output, { recursive: true });
+    }
   }
 
   async _trySaveCredentials(credentials) {
@@ -1267,8 +1305,7 @@ class TailwindPlusDownloader {
     sortSnippetsRecursively(this.componentData);
 
     this.logger.debug(`Writing component directory: ${outputDir}`);
-    fs.rmSync(outputDir, { recursive: true, force: true });
-    fs.mkdirSync(outputDir);
+    fs.mkdirSync(outputDir, { recursive: true });
 
     this._writeComponentFiles(outputDir, this.componentData, []);
 
@@ -1807,6 +1844,11 @@ function parseArgs() {
       default: 'json',
       describe: 'Output format: json (single file) or dir (directory tree of individual component files)'
     })
+    .option('overwrite', {
+      type: 'boolean',
+      default: false,
+      describe: 'Overwrite existing output file or directory without prompting'
+    })
     .check((argv) => {
       // Validate workers bounds
       if (argv.workers <= 0) {
@@ -1832,6 +1874,7 @@ function parseArgs() {
   return {
     output: argv.output,
     outputFormat: argv.outputFormat,
+    overwrite: argv.overwrite,
     workers: argv.workers,
     cookies: argv.cookies,
     session: argv.session || CONFIG.session,

--- a/test/smoke-test-urls.txt
+++ b/test/smoke-test-urls.txt
@@ -1,0 +1,30 @@
+# Smoke test URLs - representative sample for testing downloader options
+# Run with: --debug-url-file=smoke-test-urls.txt
+
+# Marketing - sections
+https://tailwindcss.com/plus/ui-blocks/marketing/sections/heroes
+https://tailwindcss.com/plus/ui-blocks/marketing/sections/feature-sections
+
+# Marketing - elements
+https://tailwindcss.com/plus/ui-blocks/marketing/elements/headers
+
+# Marketing - page example
+https://tailwindcss.com/plus/ui-blocks/marketing/page-examples/landing-pages
+
+# Application UI - forms
+https://tailwindcss.com/plus/ui-blocks/application-ui/forms/input-groups
+
+# Application UI - navigation
+https://tailwindcss.com/plus/ui-blocks/application-ui/navigation/navbars
+
+# Application UI - overlays
+https://tailwindcss.com/plus/ui-blocks/application-ui/overlays/modal-dialogs
+
+# Application UI - page example
+https://tailwindcss.com/plus/ui-blocks/application-ui/page-examples/home-screens
+
+# Ecommerce - components (no modes)
+https://tailwindcss.com/plus/ui-blocks/ecommerce/components/product-overviews
+
+# Ecommerce - page example (no modes)
+https://tailwindcss.com/plus/ui-blocks/ecommerce/page-examples/product-pages

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+#
+# Smoke tests for tailwindplus-downloader option combinations.
+#
+# Requires an authenticated session or credentials file.  Run from the repo
+# root or from within test/.
+#
+# Usage: bash test/smoke-test.sh
+
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+
+cd "$ROOT_DIR"
+
+URL_FILE="test/smoke-test-urls.txt"
+RUN_DIR="test/smoke-test-run"
+JSON_OUT="$RUN_DIR/output.json"
+DIR_OUT="$RUN_DIR/output"
+DIR_LOG_OUT="$RUN_DIR/output-log"
+
+# Colors (only when stdout is a terminal)
+if [ -t 1 ]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BOLD='\033[1m'; NC='\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; BOLD=''; NC=''
+fi
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; (( PASS += 1 )); (( TOTAL += 1 )); }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; (( FAIL += 1 )); (( TOTAL += 1 )); }
+
+header() { echo -e "\n${YELLOW}--- $1 ---${NC}"; }
+
+# Run a command, check its exit code, log pass/fail.
+# Usage: run_test "name" <expected-exit> [< /dev/null] -- cmd args...
+run_test() {
+  local name="$1"
+  local expected_exit="$2"
+  local notty="${3:-}"   # pass "notty" to redirect stdin from /dev/null
+  shift 3
+  header "$name"
+  set +o errexit
+  if [ "$notty" = "notty" ]; then
+    "$@" < /dev/null 2>&1
+  else
+    "$@" 2>&1
+  fi
+  local actual_exit=$?
+  set -o errexit
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    pass "$name"
+  else
+    fail "$name  (expected exit $expected_exit, got $actual_exit)"
+  fi
+}
+
+check_file_exists() {
+  local name="$1"
+  local path="$2"
+  if [ -e "$path" ]; then
+    pass "$name"
+  else
+    fail "$name  (not found: $path)"
+  fi
+}
+
+# ── Setup ────────────────────────────────────────────────────────────────────
+
+echo -e "${BOLD}=== TailwindPlus Downloader Smoke Tests ===${NC}"
+echo "URL file: $URL_FILE"
+echo "Output:   $RUN_DIR"
+
+rm -rf "$RUN_DIR"
+mkdir -p "$RUN_DIR"
+
+# ── JSON output ──────────────────────────────────────────────────────────────
+
+run_test "JSON: basic output to fixed path" 0 "" \
+  node tailwindplus-downloader.js \
+    --debug-url-file="$URL_FILE" \
+    --output="$JSON_OUT"
+
+check_file_exists "JSON: output file created" "$JSON_OUT"
+
+run_test "JSON: existing output, non-TTY aborts" 1 "notty" \
+  node tailwindplus-downloader.js \
+    --debug-url-file="$URL_FILE" \
+    --output="$JSON_OUT"
+
+run_test "JSON: existing output, --overwrite proceeds" 0 "" \
+  node tailwindplus-downloader.js \
+    --debug-url-file="$URL_FILE" \
+    --output="$JSON_OUT" \
+    --overwrite
+
+# ── dir output ───────────────────────────────────────────────────────────────
+
+run_test "dir: basic output to fixed path" 0 "" \
+  node tailwindplus-downloader.js \
+    --debug-url-file="$URL_FILE" \
+    --output-format=dir \
+    --output="$DIR_OUT"
+
+check_file_exists "dir: output directory created" "$DIR_OUT"
+check_file_exists "dir: metadata.json written" "$DIR_OUT/metadata.json"
+
+run_test "dir: existing output, non-TTY aborts" 1 "notty" \
+  node tailwindplus-downloader.js \
+    --debug-url-file="$URL_FILE" \
+    --output-format=dir \
+    --output="$DIR_OUT"
+
+run_test "dir: existing output, --overwrite proceeds" 0 "" \
+  node tailwindplus-downloader.js \
+    --debug-url-file="$URL_FILE" \
+    --output-format=dir \
+    --output="$DIR_OUT" \
+    --overwrite
+
+check_file_exists "dir: output recreated after --overwrite" "$DIR_OUT/metadata.json"
+
+# ── dir + --log ───────────────────────────────────────────────────────────────
+
+run_test "dir: output with --log" 0 "" \
+  node tailwindplus-downloader.js \
+    --debug-url-file="$URL_FILE" \
+    --output-format=dir \
+    --output="$DIR_LOG_OUT" \
+    --log
+
+check_file_exists "dir: --log creates correctly named .log file" "${DIR_LOG_OUT}.log"
+
+# ── dir: default timestamped path ────────────────────────────────────────────
+
+header "dir: default timestamped output path (no --output)"
+set +o errexit
+TS_OUTPUT=$(node tailwindplus-downloader.js \
+  --debug-url-file="$URL_FILE" \
+  --output-format=dir \
+  2>&1)
+TS_EXIT=$?
+set -o errexit
+echo "$TS_OUTPUT"
+
+if [ "$TS_EXIT" -eq 0 ]; then
+  pass "dir: default timestamped output path"
+  # Extract dir name from completion message and clean up
+  TS_DIR=$(echo "$TS_OUTPUT" | grep "Components saved to directory" | awk '{print $NF}')
+  [ -n "$TS_DIR" ] && rm -rf "$TS_DIR"
+else
+  fail "dir: default timestamped output path"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}=== Results: $PASS/$TOTAL passed ===${NC}"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "${RED}$FAIL test(s) failed.${NC}"
+  exit 1
+fi


### PR DESCRIPTION
- Add `--output-format {dir|json}`, defaulting to `json`.  Closes #7
- Stop silently overwriting existing output
  - Add `--overwrite` to restore previous behaviour explicitly (affects `--output` usage)
- Improve no-TTY handling for prompts (CI, automation, etc.)
- Add smoke test script with short debug URL file
- Add `create-skeleton` script to generate a lightweight skeleton JSON for use as LLM context
- Add agent skill (`contrib/tailwind-plus/`) for browsing and using components from either output format
