### PR TITLE
feat!: remove unauthenticated download mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 # Continuous integration.
 #
-# The smoke suite drives the live TailwindPlus site.  It runs in unauthenticated
-# mode here, which downloads only free sample components and needs no account, so
-# no credentials are stored in this repository.  The login-dependent tests skip
-# themselves when no session or credentials file is present.
+# The smoke suite drives the live TailwindPlus site, which requires an account.  No
+# credentials are stored in this repository, so every test that downloads skips
+# itself here and the suite covers argument handling, the abort paths and the diff
+# tool.  Unit tests run in full.
 #
-# Reads are plain HTTP, so no browser is installed: only the login form needs one,
-# and nothing that runs without credentials reaches it.
+# Nothing that runs without credentials reaches the login form, which is the only
+# part of a run that needs a browser, so none is installed.
 #
 # Because each run costs real requests against a third-party site, runs are
 # limited to pull requests and pushes to the default branch, superseded runs are

--- a/.github/workflows/site-monitor.yml
+++ b/.github/workflows/site-monitor.yml
@@ -1,0 +1,124 @@
+# Weekly check that the downloader still works against the live TailwindPlus site.
+#
+# The downloader reads someone else's site, so it stops working when that site changes
+# rather than when this repository does.  The pull request suite cannot catch that: it
+# holds no account, and the site serves nothing without one.  This job logs in on a
+# schedule and runs a real download, so a change to the page data, the format endpoint
+# or the login form surfaces here instead of the next time someone needs a download.
+#
+# Downloaded components are licensed material and must not leave the runner.  This
+# repository is public, which makes both its Actions logs and its artifacts readable by
+# anyone, so the job uploads nothing, sends every stream the run produces to a file
+# rather than to the job log, and deletes the download before it finishes.  A failure
+# reports only the downloader's own error lines, which name URLs, formats and counts.
+#
+# The download keeps the downloader's own default filenames, which the repository
+# already ignores, so nothing here can be committed even if the cleanup never runs.
+#
+# It never runs on a pull request.  The credentials are Actions secrets, which a
+# Dependabot-triggered run cannot read, so a dependency bump never gets to see them.
+#
+# Requires a site-monitor environment holding two secrets: TAILWINDPLUS_EMAIL and
+# TAILWINDPLUS_PASSWORD.
+
+name: Site monitor
+
+on:
+  schedule:
+    # Mondays, 06:17 UTC.  Off the hour, which is when scheduled runs queue worst.
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+# A run sets the account-level format and restores it at the end, so two overlapping
+# runs would fight over it.
+concurrency:
+  group: site-monitor
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # Holds the credentials, so only a job naming this environment can read them.
+    #
+    # Intentionally left without a deployment branch restriction.  The job has no
+    # pull_request trigger and so never runs on a pull request by itself, which leaves
+    # dispatching it against a branch as the only way to check a change that nothing short
+    # of a real download would catch.  Restricting the environment to the default branch
+    # would take that away.
+    environment: site-monitor
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: npm
+
+      - run: npm ci --ignore-scripts
+
+      # The login form is the one interaction that needs a browser, and this job always
+      # logs in: a runner starts with no saved session.
+      - run: npx playwright install --with-deps chromium
+
+      # Written through the environment rather than interpolated into the script, so the
+      # values never appear in the command line.
+      - name: Write credentials file
+        env:
+          TAILWINDPLUS_EMAIL: ${{ secrets.TAILWINDPLUS_EMAIL }}
+          TAILWINDPLUS_PASSWORD: ${{ secrets.TAILWINDPLUS_PASSWORD }}
+        run: |
+          node -e 'const fs = require("fs");
+            fs.writeFileSync(".tailwindplus-downloader-credentials.json",
+              JSON.stringify({ email: process.env.TAILWINDPLUS_EMAIL, password: process.env.TAILWINDPLUS_PASSWORD }));'
+
+      # Discovery reads the whole product tree before --debug-short-test narrows the
+      # download to two pages, so the listing that this job exists to watch is covered in
+      # full while the download itself stays small.
+      #
+      # --output is left at its default, so the download and its log are named
+      # tailwindplus-components-<timestamp>, which .gitignore already covers.  --log sends
+      # the downloader's own output to that log; the redirect catches what does not go
+      # through the logger, which is the stack a fatal error prints.  Both logs are named
+      # to match the same ignore rule, and so also the same glob below.
+      - name: Run a short download
+        run: node tailwindplus-downloader.js --debug-short-test --log > tailwindplus-components-console.log 2>&1
+
+      # A run that captures nothing still exits 0, which would let an empty listing pass
+      # as a healthy check.  The count is the only thing about the download this job
+      # prints.
+      - name: Check the download captured components
+        run: |
+          node -e 'const fs = require("fs");
+            const name = fs.readdirSync(".").find(f => /^tailwindplus-components-.*\.json$/.test(f));
+            if (!name) { console.error("The run wrote no output file."); process.exit(1); }
+            const out = JSON.parse(fs.readFileSync(name, "utf8"));
+            const count = out.component_count;
+            if (!Number.isInteger(count) || count < 1) {
+              console.error("Downloaded " + count + " components; the site returned a listing but no content.");
+              process.exit(1);
+            }
+            console.log("Downloaded " + count + " components.");'
+
+      # Error and warning lines only, capped: enough to say what the site did, without
+      # putting the body of the run into a public log.
+      - name: Report the failure
+        if: failure()
+        run: |
+          reported=$(grep -hE '\[(ERROR|WARN|FATAL)' tailwindplus-components-*.log 2>/dev/null | head -50 || true)
+          if [ -n "$reported" ]; then
+            echo "$reported"
+          else
+            echo 'The run failed before it logged an error.'
+          fi
+
+      - name: Remove the download, the logs and the credentials
+        if: always()
+        run: |
+          rm -f tailwindplus-components-*.json tailwindplus-components-*.log \
+            .tailwindplus-downloader-credentials.json .tailwindplus-downloader-session.json

--- a/README.md
+++ b/README.md
@@ -182,8 +182,6 @@ npx github:richardkmichael/tailwindplus-downloader#latest --retries 5
 # Print the resolved configuration and exit
 npx github:richardkmichael/tailwindplus-downloader#latest --show-config
 
-# Unauthenticated (downloads free/demo components only)
-npx github:richardkmichael/tailwindplus-downloader#latest --unauthenticated
 ```
 
 Within the repo, or with a global install, short-form aliases are available:
@@ -373,9 +371,6 @@ the response rather than off the rendered page.  Almost every step is a plain HT
 
 A browser is launched only for the login form.  A run with a saved session never starts one.
 
-`--unauthenticated` works the same way, except the format applies per component rather than to the
-whole account, so every format of a page is collected in one visit.
-
 ## Development
 
 ### Code Quality
@@ -406,9 +401,9 @@ npm run test:unit
 ```
 
 The smoke tests cover option permutations (JSON and directory output, `--overwrite`, `--log`,
-default timestamped paths, interrupts) using real downloads.  The ones that need no login run
-against free sample components; the rest skip themselves unless a session or credentials file is
-present, so the suite is usable without an account.
+default timestamped paths, interrupts) using real downloads.  Every test that downloads skips
+itself unless a session or credentials file is present, leaving argument handling, the abort paths
+and the diff tool to run without an account.
 
 ```bash
 npm run smoke-test    # smoke tests only

--- a/docs/TAILWINDPLUS_ARCHITECTURE.md
+++ b/docs/TAILWINDPLUS_ARCHITECTURE.md
@@ -6,6 +6,21 @@ site is an InertiaJS application, which shapes both what can be read and how the
 Everything here was observed against the live site.  Where a behaviour is relied upon, the way it
 was confirmed is stated, because these are someone else's implementation details and can change.
 
+## The whole `/plus` area requires a session
+
+Every path under `/plus` answers an unauthenticated request with a 302 to `/plus/login`, including
+the discovery index and the marketing entry point the site's own homepage links to.  Nothing below
+`/plus` is readable without a session, so a run begins by logging in.
+
+The redirect is a plain application-level 302 that sets a Laravel session cookie, not a bot
+challenge or a rate limit: there is no interstitial and no 403, and an authenticated request from
+the same address succeeds.  Reading it as throttling would send a diagnosis in the wrong direction.
+
+A downloader that follows the redirect parses the login page's `data-page`, which carries
+`component: "Login"` and no `props.products`.  Discovery therefore fails on absent product data
+rather than on the redirect itself, so the error a gated run reports names the symptom and not the
+cause.
+
 ## The data is in the page
 
 Every component page is server-rendered with its data embedded as JSON:
@@ -56,26 +71,13 @@ Its value is the `XSRF-TOKEN` cookie, URL-decoded.
 `snippet_lang` sets all three axes at once.  There is no need to change framework, version and mode
 separately.
 
-### Scope differs by authentication, and that shapes everything
+### A format change applies to the whole account
 
-| Session | Scope of a format change | Consequence |
-|---|---|---|
-| Authenticated | The whole account | One request, then every page returns that format |
-| Anonymous | The named component only | Each component must be set individually |
+A PUT naming one component changes every component on the page, and a PUT with no `uuid` at all
+works the same way, so the `uuid` is omitted.  Confirmed by measurement rather than assumption.
 
-Confirmed by measurement rather than assumption.  Authenticated, a PUT naming one component
-changed all twelve components on the page — and a PUT with no `uuid` at all also worked, so the
-downloader omits it.  Anonymous, the same request changed only the named component and left a
-second component on the same page untouched; a PUT without a `uuid` was accepted and changed
-nothing.
-
-This is why the two modes are shaped differently and cannot be collapsed into one:
-
-- Authenticated: set the format once, then fetch every page.  Repeat for each of the 18 formats.
-- Anonymous: set every component on a page, read the page once, and repeat per format.  A page's
-  whole format set is collected in one visit.
-
-The second is why anonymous runs cost one read per format rather than one per component per format.
+This is what lets a run set the format once and then fetch every page, repeating for each of the
+18 formats, rather than setting a format per component.
 
 ### Reading the response
 
@@ -133,9 +135,9 @@ formats missing.
 
 ### `downloadable` marks free components
 
-Anonymous, only components with `downloadable: true` return code.  Everything else requires a
-license.  Which components are free is TailwindPlus's choice and changes: some subcategories offer
-one free sample, some offer two, and some — footers, for instance — offer none at all.
+Components carry a `downloadable` flag.  It once distinguished the free samples an anonymous
+visitor could read from the rest, which required a license; with the whole `/plus` area behind
+login it no longer separates what a session can read.
 
 ## Format combinations
 
@@ -153,7 +155,8 @@ Modes are code variants, not display preferences:
 
 ## Session cookies
 
-An anonymous GET of any page returns everything needed to make a format request:
+A GET of any `/plus` page returns everything needed to make a format request, including the
+redirect an unauthenticated request receives:
 
 | Cookie | Role |
 |---|---|
@@ -219,7 +222,7 @@ The site is not a documented API, so it is worth knowing what the tool is expose
 
 - The `data-page` attribute, and the shape of `props.subcategory.components`
 - The format endpoint, its `snippet_lang` spelling, and the CSRF header it requires
-- The scope difference between authenticated and anonymous format changes
+- The account-wide scope of a format change
 - The login form, the only remaining browser interaction
 
 A change to any of these surfaces as a failed run rather than as wrong output: format verification

--- a/tailwindplus-downloader.js
+++ b/tailwindplus-downloader.js
@@ -297,57 +297,6 @@ function isEcommerceUrl(url) {
 }
 
 /**
- * Picks one record per downloadable component.
- *
- * Every component is listed twice, as a light and a dark preview record with its own uuid and its
- * own snippet.  Exactly one is wanted per component, since the format is then driven across all of
- * them anyway, and two records of the same name would collide in the output.  The light record is
- * preferred so the captured set matches what the browser-driven path produced; taking whichever is
- * flagged means a component marked downloadable only in its dark record is captured rather than
- * silently skipped.
- *
- * @param {Object[]} components - Components from a subcategory's page data
- * @returns {Object[]} One record per downloadable component
- */
-function selectFreeComponents(components) {
-  const byName = new Map();
-
-  for (const component of components) {
-    if (!component.downloadable) {
-      continue;
-    }
-    const chosen = byName.get(component.name);
-    if (!chosen || (chosen.preview !== 'light' && component.preview === 'light')) {
-      byName.set(component.name, component);
-    }
-  }
-
-  return [...byName.values()];
-}
-
-/**
- * Reduces a format list to one entry per framework and version, dropping the mode.  Components
- * that have no mode render identically in all three, so a pass per mode fetches the same content.
- *
- * @param {Format[]} formats - Formats to reduce
- * @returns {Format[]} One format per framework/version pair, in the order given
- */
-/**
- * Reports whether a page's components carry modes.
- *
- * Components with no mode render identically in all three, so one pass per framework and version
- * covers them.  A component with no snippet says nothing either way and is ignored: treating it as
- * moded would drive a mode-less page through all 18 formats and collect the same six snippets three
- * times over.
- *
- * @param {Object[]} components - Components from a subcategory's page data
- * @returns {boolean} True when any component carries a mode
- */
-function componentsHaveModes(components) {
-  return components.some(component => component.snippet && component.snippet.mode !== null);
-}
-
-/**
  * Decides what becomes of a failed page.
  *
  * Separated from the queue and the logging so the boundary can be tested: an off-by-one here is
@@ -360,18 +309,6 @@ function componentsHaveModes(components) {
  */
 function retryDecision(retryCount, retryLimit) {
   return retryCount < retryLimit ? 'retry' : 'exhausted';
-}
-
-function uniqueFrameworkVersions(formats) {
-  const seen = new Set();
-  return formats.filter(format => {
-    const key = `${format.framework}-v${format.version}`;
-    if (seen.has(key)) {
-      return false;
-    }
-    seen.add(key);
-    return true;
-  });
 }
 
 /**
@@ -417,8 +354,7 @@ function subcategoryOfRequiredFormat(pageData, url, expectedFormat) {
 
 /**
  * Sends the format-setting PUT through the given HTTP client, authenticated with the XSRF token
- * from the client's own cookie jar.  Authenticated it sets the account-wide format; with a `uuid`
- * in the data it sets one component's format for the calling session.
+ * from the client's own cookie jar, setting the account-wide format.
  *
  * The response redirects back to the page the format was set from, which there is no reason to
  * follow: every caller verifies with a read of its own.
@@ -470,8 +406,7 @@ function createConfig() {
       plus: `${base}/plus`,
       discovery: `${base}/plus/ui-blocks`,
       eCommerce: `${base}/plus/ui-blocks/ecommerce`,
-      // Sets the snippet format.  Unauthenticated it applies per component uuid, for the calling
-      // session only; authenticated it sets the account-wide preference.
+      // Sets the account-wide snippet format preference.
       language: `${base}/plus/ui-blocks/language`
     },
 
@@ -591,9 +526,7 @@ class TailwindPlusDownloader {
     // Subcategories are keyed by the dotted "product.category.subcategory" path.
     this.descriptions = { products: {}, subcategories: {} };
 
-    // Components actually downloaded, which is fewer than the discovered
-    // `componentCount` in unauthenticated mode: only free samples are reachable.
-    // Set when the output metadata is built.
+    // Components actually downloaded.  Set when the output metadata is built.
     this.capturedComponentCount = null;
 
     this.urls = [];
@@ -602,8 +535,7 @@ class TailwindPlusDownloader {
     this.currentFormat = null;
 
     // The account-level format in effect when the run started.  The site persists the format
-    // server-side, so it is restored when the format passes finish.  Null in unauthenticated
-    // mode, which has no account format.
+    // server-side, so it is restored when the format passes finish.
     this.initialFormat = null;
 
     // Mid-run re-authentication state.  `sessionGeneration` increments on each successful
@@ -638,14 +570,8 @@ class TailwindPlusDownloader {
       this.urlCount = discovery.urlCount;
       this.componentCount = discovery.componentCount;
 
-      let formats;
-      if (this.options.unauthenticated) {
-        // In unauthenticated mode, use default format order (no detection needed)
-        formats = this._generateFormats();
-      } else {
-        this.initialFormat = await this._detectFormat();
-        formats = this._generateFormats(this.initialFormat);
-      }
+      this.initialFormat = await this._detectFormat();
+      const formats = this._generateFormats(this.initialFormat);
 
       this._showStartMessage();
       await this._processFormats(formats);
@@ -731,8 +657,7 @@ class TailwindPlusDownloader {
   /**
    * Prepares the run's HTTP client and session: sets up the tracing directory if enabled, opens
    * the request context from any saved session, and logs in when the session is missing or
-   * invalid.  Unauthenticated mode needs no login and stops at the request context.
-   * `session` is a filename for a Playwright `storageState` file (saved after successful login)
+   * invalid.  `session` is a filename for a Playwright `storageState` file (saved after successful login)
    *
    * @throws {DownloaderError} When login is needed and fails
    */
@@ -749,11 +674,6 @@ class TailwindPlusDownloader {
     }
 
     await this._openRequestContext();
-
-    if (this.options.unauthenticated) {
-      this.logger.debug('Unauthenticated mode - skipping login');
-      return;
-    }
 
     if (await this._validateSession()) {
       this.logger.debug('Using existing valid session');
@@ -773,7 +693,7 @@ class TailwindPlusDownloader {
    */
   async _openRequestContext() {
     const contextOptions = {};
-    if (!this.options.unauthenticated && fs.existsSync(this.session)) {
+    if (fs.existsSync(this.session)) {
       contextOptions.storageState = this.session;
       this.logger.debug('Loading saved session');
     }
@@ -1340,10 +1260,6 @@ class TailwindPlusDownloader {
   }
 
   _showStartMessage() {
-    if (this.options.unauthenticated) {
-      this.logger.info('Unauthenticated mode: downloading free components only');
-    }
-
     if (this.options.debugTrace) {
       this.logger.info(`Tracing enabled. Traces will be saved to: ${this.tracesDir}`);
     }
@@ -1371,9 +1287,6 @@ class TailwindPlusDownloader {
    * eCommerce pages are the exception: they have no mode controls and render identically in every
    * mode, so they are queued once per framework/version rather than once per format.
    *
-   * In unauthenticated mode, workers handle all formats per-page in a single visit, since format
-   * controls work per-component without authentication.
-   *
    * @param {string[]} formats - Array of format identifiers to process
    * @throws {DownloaderError} When worker creation fails or format processing fails
    */
@@ -1387,20 +1300,6 @@ class TailwindPlusDownloader {
     for (let i = 0; i < numberOfWorkers; i++) {
       const worker = new Worker(i + 1, this, this.baseLogger);
       workers.push(worker);
-    }
-
-    // In unauthenticated mode, workers handle all formats per-page
-    if (this.options.unauthenticated) {
-      this.logger.info(`Unauthenticated mode: downloading ${formats.length} formats per page`);
-      this.formats = formats;  // Workers will use this
-      this._populateJobQueue();
-
-      const workerPromises = workers.map(worker => worker.start());
-      await Promise.all(workerPromises);
-      await Promise.all(workers.map(worker => worker.stop()));
-
-      this.logger.debug('All formats downloaded');
-      return;
     }
 
     // eCommerce pages render the same content in every mode, so only the first mode pass of
@@ -1499,8 +1398,7 @@ class TailwindPlusDownloader {
    * replace the error that ended a failed one.
    */
   async _restoreInitialFormat() {
-    // Unauthenticated mode has no account format to restore, and an authenticated run that aborted
-    // before detection never changed one.
+    // A run that aborted before detection never changed the account format.
     if (!this.initialFormat) {
       return;
     }
@@ -1771,12 +1669,6 @@ class Worker {
     this.downloader = downloader;
     this.state = 'stopped';
 
-    // Unauthenticated reads go over plain HTTP.  The context is per worker because the site
-    // scopes the format to the calling session, so a shared one would let workers overwrite
-    // each other's component formats.
-    this.requestContext = null;
-    this.inertiaVersion = null;
-
     // Pad the worker ID to ensure consistent identifier length
     const identifier = `Worker ${id.toString().padStart(2, ' ')}`;
     this.logger = logger.prefix(identifier);
@@ -1784,8 +1676,7 @@ class Worker {
 
   /**
    * Starts the worker and begins processing jobs from the downloader's job queue.
-   * Authenticated jobs are plain HTTP GETs through the downloader's request context; only
-   * unauthenticated mode opens a request context of its own, for its per-session format state.
+   * Jobs are plain HTTP GETs through the downloader's request context.
    *
    * If a job (URL to download in the current format) fails, it is returned to the main downloader,
    * and re-queued to be attempted again; up to the --retries limit.  A job generally fails with a
@@ -1804,12 +1695,6 @@ class Worker {
 
     this.state = 'started';
 
-    // Unauthenticated extraction reads over plain HTTP and needs no browser page.  Its own
-    // request context gives it its own cookie jar, and so its own per-component format state.
-    if (this.downloader.options.unauthenticated) {
-      this.requestContext = await request.newContext();
-    }
-
     // Job processing loop.  An interrupt stops the worker taking new jobs; the job already in
     // flight is allowed to finish rather than being abandoned mid-request.
     while (!this.downloader.interrupted && this.downloader.jobQueue.length > 0) {
@@ -1820,10 +1705,7 @@ class Worker {
         this.logger.debug(`Started job: ${job.url}`);
         job.status = 'processing';
 
-        // Use unauthenticated extraction when in that mode
-        const pageData = this.downloader.options.unauthenticated
-          ? await this._extractUnauthenticatedPageData(job)
-          : await this.extractPageData(job);
+        const pageData = await this.extractPageData(job);
 
         job.data = pageData;
         job.status = 'completed';
@@ -1906,183 +1788,10 @@ class Worker {
   }
 
   /**
-   * Reads a page as an Inertia partial, returning the same props as JSON at roughly a third of
-   * the bytes of the rendered HTML.  Falls back to a full read when no version is known yet, and
-   * again if the site is redeployed mid-run and rejects the version it gave us.
-   *
-   * @param {string} url - Page URL
-   * @returns {Promise<Object>} Parsed page data
-   * @throws {DownloaderError} When the request fails with a non-2xx status
+   * Stops the worker.  Workers read through the downloader's request context and hold no
+   * resources of their own, so there is nothing to dispose.
    */
-  async _readUnauthenticatedPage(url) {
-    if (!this.inertiaVersion) {
-      return this._readUnauthenticatedPageFully(url);
-    }
-
-    const response = await this.requestContext.get(url, {
-      headers: {
-        'x-inertia': 'true',
-        'x-inertia-version': this.inertiaVersion,
-        'x-requested-with': 'XMLHttpRequest',
-        accept: 'text/html, application/xhtml+xml'
-      },
-      timeout: CONFIG.timeout
-    });
-
-    // The site answers 409 when the deployed asset version has moved on.
-    if (response.status() === 409) {
-      this.logger.debug('Inertia version stale, re-reading the full page');
-      this.inertiaVersion = null;
-      return this._readUnauthenticatedPageFully(url);
-    }
-
-    if (!response.ok()) {
-      throw new DownloaderError(`Request to ${url} failed with HTTP ${response.status()}`);
-    }
-
-    return JSON.parse(await response.text());
-  }
-
-  /**
-   * Reads a page as rendered HTML and parses the `data-page` attribute out of it, recording the
-   * Inertia version so later reads of the same page can use the smaller JSON response.
-   *
-   * @param {string} url - Page URL
-   * @returns {Promise<Object>} Parsed page data
-   * @throws {DownloaderError} When the request fails or carries no page data
-   */
-  async _readUnauthenticatedPageFully(url) {
-    const response = await this.requestContext.get(url, { timeout: CONFIG.timeout });
-    if (!response.ok()) {
-      throw new DownloaderError(`Request to ${url} failed with HTTP ${response.status()}`);
-    }
-
-    const pageData = parseDataPageFromHtml(await response.text());
-    if (!pageData) {
-      throw new DownloaderError(`No data-page attribute found on ${url}`);
-    }
-
-    this.inertiaVersion = pageData.version;
-    return pageData;
-  }
-
-  /**
-   * Sets the format of a single component for this worker's session.
-   *
-   * Unauthenticated, the site scopes this to the component uuid, so workers do not disturb each
-   * other's pages and every format of a page can be read without a global setting.  Mode is
-   * accepted but ignored for components that have none.
-   *
-   * @param {string} uuid - Component uuid
-   * @param {Format} format - Target format
-   * @throws {DownloaderError} When the request is rejected
-   */
-  async _setUnauthenticatedFormat(uuid, format) {
-    try {
-      await putSnippetLanguage(this.requestContext, { uuid, snippet_lang: format.toString() });
-    } catch (error) {
-      throw new DownloaderError(`Setting format ${format} on ${uuid} failed: ${error.message}`);
-    }
-  }
-
-  /**
-   * Extracts every format of a page's free components over plain HTTP, with no browser page.
-   *
-   * The format is set per component with a PUT and the whole page is then read once, so a page
-   * costs one read per format rather than one per component per format.
-   *
-   * @param {Object} job - Job object containing URL
-   * @returns {Promise<Object>} Component data organized by hierarchy with all format snippets
-   * @throws {DownloaderError} When a request fails or the page carries no data
-   */
-  async _extractUnauthenticatedPageData(job) {
-    const url = job.url;
-
-    const pageData = await this._readUnauthenticatedPage(url);
-    const subcategory = pageData.props.subcategory;
-    const product = subcategory.category.product.name;
-    const category = subcategory.category.name;
-
-    this.downloader._recordSubcategoryDescription(product, category, subcategory);
-
-    const freeComponents = selectFreeComponents(subcategory.components);
-    if (freeComponents.length === 0) {
-      this.logger.debug(`No downloadable components on ${url}`);
-      return {};
-    }
-
-    this.logger.debug(`Found ${freeComponents.length} downloadable components`);
-
-    const formats = componentsHaveModes(freeComponents)
-      ? this.downloader.formats
-      : uniqueFrameworkVersions(this.downloader.formats);
-
-    const snippetsByUuid = new Map(freeComponents.map(component => [component.uuid, []]));
-
-    for (const format of formats) {
-      // One job covers every format of a page, so waiting for it to finish would make an
-      // interrupt feel unresponsive.  Stop between formats; an interrupted run writes no output.
-      if (this.downloader.interrupted) {
-        break;
-      }
-
-      for (const component of freeComponents) {
-        await this._setUnauthenticatedFormat(component.uuid, format);
-      }
-
-      const formatted = await this._readUnauthenticatedPage(url);
-      for (const component of formatted.props.subcategory.components) {
-        const snippets = snippetsByUuid.get(component.uuid);
-        if (snippets && component.snippet) {
-          snippets.push(this._shapeSnippet(component.snippet));
-        }
-      }
-    }
-
-    // The uuid tying a format request to its component in the response is TailwindPlus-internal
-    // and guaranteed nothing: if it changed underneath a page, the responses would stop matching
-    // and the snippets would quietly come up short.  Fail the job instead, so it is retried and
-    // ultimately reported, rather than writing a component with formats missing.
-    if (!this.downloader.interrupted) {
-      for (const component of freeComponents) {
-        const captured = snippetsByUuid.get(component.uuid).length;
-        if (captured !== formats.length) {
-          throw new DownloaderError(
-            `Captured ${captured} of ${formats.length} formats for "${component.name}" on ${url}`
-          );
-        }
-      }
-    }
-
-    const componentData = {};
-    componentData[product] = {};
-    componentData[product][category] = {};
-    componentData[product][category][subcategory.name] = {};
-
-    for (const component of freeComponents) {
-      const snippets = snippetsByUuid.get(component.uuid);
-      componentData[product][category][subcategory.name][component.name] = {
-        name: component.name,
-        snippets
-      };
-      this.logger.debug(`Collected ${snippets.length} snippets for ${component.name}`);
-    }
-
-    this.logger.debug(`Extracted ${freeComponents.length} components from ${product}/${category}/${subcategory.name}`);
-    return componentData;
-  }
-
-  /**
-   * Stops the worker, disposing the unauthenticated request context if one was opened
-   * (authenticated workers hold no resources of their own)
-   */
-  async stop() {
-    if (this.requestContext) {
-      await this.requestContext.dispose();
-      this.requestContext = null;
-      this.inertiaVersion = null;
-    }
-
+  stop() {
     this.state = 'stopped';
   }
 }
@@ -2156,11 +1865,6 @@ function parseArgs() {
     .option('debug-trace', {
       type: 'boolean',
       describe: 'Enable tracing to debug browser interactions, saved in directory `[OUTPUT].traces`'
-    })
-    .option('unauthenticated', {
-      type: 'boolean',
-      default: false,
-      describe: 'Download only free (unauthenticated) components without login'
     })
     .option('output-format', {
       choices: ['json', 'dir'],
@@ -2262,10 +1966,7 @@ export {
   decodeHtmlEntities,
   parseDataPageFromHtml,
   isEcommerceUrl,
-  selectFreeComponents,
-  componentsHaveModes,
   retryDecision,
-  uniqueFrameworkVersions,
   subcategoryOfRequiredFormat,
   sortSnippetsRecursively,
   Format

--- a/test/ecommerce-test-url.txt
+++ b/test/ecommerce-test-url.txt
@@ -1,10 +1,6 @@
 # An eCommerce page, which has no light/dark/system controls.  Its components carry a null mode
 # and yield 6 snippets each (one per framework/version) rather than 18, exercising the mode-less
-# path in unauthenticated extraction and the suffix-free filenames in directory output.
+# path and the suffix-free filenames in directory output.
 #
-# It also has more than one free component, so the per-component loop actually iterates.
-#
-# This depends on TailwindPlus continuing to offer free samples here.  If they stop, the
-# "unauthenticated: dir output format" test will fail; pick another eCommerce page with free
-# components rather than loosening the assertion.
+# It also has more than one component, so the per-component loop actually iterates.
 https://tailwindcss.com/plus/ui-blocks/ecommerce/components/product-lists

--- a/test/no-free-components-url.txt
+++ b/test/no-free-components-url.txt
@@ -1,7 +1,0 @@
-# A page whose components are all paid — used to check that unauthenticated mode
-# completes cleanly with nothing to capture, rather than erroring.
-#
-# This depends on TailwindPlus offering no free sample on this page.  If they add
-# one, the "unauthenticated: page with no free components" smoke test will fail;
-# pick another all-paid page rather than loosening the assertion.
-https://tailwindcss.com/plus/ui-blocks/marketing/sections/footers

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -4,9 +4,9 @@
 #
 # Run from the repo root or from within test/.
 #
-# The unauthenticated tests need no login and always run.  The rest need a
-# session or credentials file and skip when neither is present, so this suite
-# is usable in CI without exposing an account.
+# Every test that downloads needs a session or credentials file and skips when
+# neither is present, so this suite runs in CI without exposing an account —
+# covering argument handling, the abort paths and the diff tool.
 #
 # Usage: bash test/smoke-test.sh [--trace] [filter]
 #
@@ -375,7 +375,6 @@ require_auth() {
 
 ONE_URL_FILE="test/one-test-url.txt"
 MANY_URL_FILE="test/many-test-urls.txt"
-NO_FREE_URL_FILE="test/no-free-components-url.txt"
 ECOMMERCE_URL_FILE="test/ecommerce-test-url.txt"
 
 DEFAULT_SESSION=".tailwindplus-downloader-session.json"
@@ -386,13 +385,13 @@ RUN_DIR="test/smoke-test-runs/run.$$"
 HAS_CREDS=false
 [[ -f "$DEFAULT_CREDS" ]] && HAS_CREDS=true
 
-# The unauthenticated tests need no login, so a run with no session or credentials
-# is valid — the authenticated tests skip instead of aborting the run.
+# A run with no session or credentials is valid — the tests that download skip
+# instead of aborting the run, leaving the offline tests to carry it.
 HAS_AUTH=false
 [[ -f "$DEFAULT_SESSION" || -f "$DEFAULT_CREDS" ]] && HAS_AUTH=true
 
 if ! $HAS_AUTH; then
-  echo "No session or credentials found; running unauthenticated tests only."
+  echo "No session or credentials found; running offline tests only."
   echo "  $DEFAULT_SESSION"
   echo "  $DEFAULT_CREDS"
 fi
@@ -410,6 +409,8 @@ test_json_basic() {
 
   run_cmd 0 "" downloader --debug-url-file="$MANY_URL_FILE" --output="$dir/output.json" --log --debug
   check_file_exists "output file created" "$dir/output.json"
+  check_component_count "components captured" "$dir/output.json" min 1
+  check_descriptions "descriptions captured" "$dir/output.json"
 
   [[ "$FAIL" -eq "$fail_before" ]] && rm -rf "$dir"
 }
@@ -433,6 +434,8 @@ test_json_overwrite() {
   local fail_before=$FAIL
 
   run_cmd 0 "" downloader --debug-url-file="$ONE_URL_FILE" --output="$dir/output.json" --overwrite --log --debug
+  # A moded page: 3 frameworks x 2 versions x 3 modes.
+  check_snippet_formats "every format captured once" "$dir/output.json" 18
 
   [[ "$FAIL" -eq "$fail_before" ]] && rm -rf "$dir"
 }
@@ -447,6 +450,7 @@ test_dir_basic() {
   check_file_exists "output directory created" "$dir/output"
   check_file_exists "metadata.json written" "$dir/output/metadata.json"
   check_file_exists "descriptions.json written" "$dir/output/descriptions.json"
+  check_component_count "components captured" "$dir/output/metadata.json" min 1
 
   [[ "$FAIL" -eq "$fail_before" ]] && rm -rf "$dir"
 }
@@ -545,60 +549,18 @@ test_auth_relogin() {
   [[ "$FAIL" -eq "$fail_before" ]] && rm -rf "$dir"
 }
 
-# Unauthenticated mode captures only the free sample components, so these tests
-# need no session or credentials and are the subset CI can run.
-
-test_unauth_no_credentials() {
-  local dir="$RUN_DIR/12-unauth-no-credentials"
+# eCommerce pages have no mode controls, so their components carry a null mode and yield 6
+# snippets each rather than 18.  This is the only test that reaches the mode-less path and the
+# suffix-free filenames it produces in directory output.
+test_dir_ecommerce() {
+  require_auth || return
+  local dir="$RUN_DIR/12-dir-ecommerce"
   mkdir -p "$dir"
   local fail_before=$FAIL
 
-  # Run from inside the subdir, passing no auth arguments, so the default session
-  # and credentials paths resolve to a directory that has neither.  This is what
-  # proves the mode needs no account.
-  # shellcheck disable=SC2016 # $1/$@ expand inside the bash -c subshell, not here.
-  run_cmd 0 "" \
-    bash -c 'cd "$1" && shift && node "$@"' _ "$dir" \
-      "$ROOT_DIR/tailwindplus-downloader.js" \
-      --unauthenticated \
-      --debug-url-file="$ROOT_DIR/$ONE_URL_FILE" \
-      --output=output.json \
-      "${TRACE_ARGS[@]+"${TRACE_ARGS[@]}"}"
-
-  check_file_exists "output file created" "$dir/output.json"
-  check_file_absent "no session file written" "$dir/$DEFAULT_SESSION"
-  check_component_count "free components captured" "$dir/output.json" min 1
-  check_descriptions "descriptions captured" "$dir/output.json"
-  # A moded page: 3 frameworks x 2 versions x 3 modes.
-  check_snippet_formats "every format captured once" "$dir/output.json" 18
-
-  [[ "$FAIL" -eq "$fail_before" ]] && rm -rf "$dir"
-}
-
-test_unauth_no_free_components() {
-  local dir="$RUN_DIR/13-unauth-no-free-components"
-  mkdir -p "$dir"
-  local fail_before=$FAIL
-
-  run_cmd 0 "" downloader --unauthenticated --debug-url-file="$NO_FREE_URL_FILE" --output="$dir/output.json" --log --debug
-  check_component_count "completes with nothing captured" "$dir/output.json" exact 0
-
-  [[ "$FAIL" -eq "$fail_before" ]] && rm -rf "$dir"
-}
-
-test_unauth_dir_output() {
-  local dir="$RUN_DIR/14-unauth-dir-output"
-  mkdir -p "$dir"
-  local fail_before=$FAIL
-
-  # An eCommerce page, so this covers the mode-less extraction path and the suffix-free filenames
-  # it produces, neither of which the moded page used elsewhere reaches.  It has more than one free
-  # component, so the per-component loop iterates.
-  run_cmd 0 "" downloader --unauthenticated --debug-url-file="$ECOMMERCE_URL_FILE" --output-format=dir --output="$dir/output" --log --debug
+  run_cmd 0 "" downloader --debug-url-file="$ECOMMERCE_URL_FILE" --output-format=dir --output="$dir/output" --log --debug
   check_file_exists "output directory created" "$dir/output"
-  check_file_exists "metadata.json written" "$dir/output/metadata.json"
-  check_file_exists "descriptions.json written" "$dir/output/descriptions.json"
-  check_component_count "multiple free components captured" "$dir/output/metadata.json" min 2
+  check_component_count "components captured" "$dir/output/metadata.json" min 2
   check_modeless_filenames "mode-less snippet filenames" "$dir/output"
   # A mode-less page: 3 frameworks x 2 versions, with no mode to vary.
   check_snippet_file_count "every format written once" "$dir/output" 6
@@ -607,26 +569,28 @@ test_unauth_dir_output() {
 }
 
 test_url_file_empty() {
+  require_auth || return
   local dir="$RUN_DIR/15-url-file-empty"
   mkdir -p "$dir"
   printf '# a comment, and no URLs\n\n' > "$dir/urls.txt"
   local fail_before=$FAIL
 
   # An unfiltered run would download every component, so this must abort rather than proceed.
-  run_cmd 1 "notty" downloader --unauthenticated --debug-url-file="$dir/urls.txt" --output="$dir/output.json"
+  run_cmd 1 "notty" downloader --debug-url-file="$dir/urls.txt" --output="$dir/output.json"
   check_file_absent "no output written" "$dir/output.json"
 
   [[ "$FAIL" -eq "$fail_before" ]] && rm -rf "$dir"
 }
 
 test_interrupt_shuts_down() {
+  require_auth || return
   local dir="$RUN_DIR/16-interrupt"
   mkdir -p "$dir"
   local fail_before=$FAIL
 
   # Many URLs so the run cannot finish before the interrupt arrives.
   run_and_interrupt 130 'Started job:' "$dir/output.log" \
-    --unauthenticated --debug-url-file="$MANY_URL_FILE" --output="$dir/output.json" --log --debug
+    --debug-url-file="$MANY_URL_FILE" --output="$dir/output.json" --log --debug
 
   check_log_contains "interrupt reported" "$dir/output.log" 'Received SIGINT'
   check_log_contains "teardown reached" "$dir/output.log" 'Shutting down'
@@ -716,12 +680,12 @@ test_options_reach_the_run() {
   local fail_before=$FAIL
 
   # shellcheck disable=SC2016 # $1/$2 expand inside the bash -c subshell, not here.
-  run_cmd 0 "" bash -c 'node "$1" --show-config --unauthenticated --retries=7 --workers=3 > "$2" 2>&1' \
+  run_cmd 0 "" bash -c 'node "$1" --show-config --overwrite --retries=7 --workers=3 > "$2" 2>&1' \
     _ "$ROOT_DIR/tailwindplus-downloader.js" "$dir/config.json"
 
   check_log_contains "retries carried through" "$dir/config.json" '"retries": 7'
   check_log_contains "workers carried through" "$dir/config.json" '"workers": 3'
-  check_log_contains "unauthenticated carried through" "$dir/config.json" '"unauthenticated": true'
+  check_log_contains "overwrite carried through" "$dir/config.json" '"overwrite": true'
   check_log_contains "unset options listed" "$dir/config.json" '"debugTrace": null'
 
   [[ "$FAIL" -eq "$fail_before" ]] && rm -rf "$dir"
@@ -759,9 +723,7 @@ TESTS=(
   "auth: credentials present, no session|test_auth_fresh_login"
   "auth: no credentials, no session, non-TTY aborts|test_auth_no_creds"
   "auth: invalid session, re-login succeeds|test_auth_relogin"
-  "unauthenticated: no credentials needed|test_unauth_no_credentials"
-  "unauthenticated: page with no free components|test_unauth_no_free_components"
-  "unauthenticated: dir output format|test_unauth_dir_output"
+  "dir: eCommerce mode-less output|test_dir_ecommerce"
   "URL file with no URLs aborts|test_url_file_empty"
   "interrupt shuts down cleanly|test_interrupt_shuts_down"
   "diff: component counts reported|test_diff_component_counts"

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10,10 +10,7 @@ import {
   decodeHtmlEntities,
   parseDataPageFromHtml,
   isEcommerceUrl,
-  selectFreeComponents,
-  componentsHaveModes,
   retryDecision,
-  uniqueFrameworkVersions,
   subcategoryOfRequiredFormat,
   sortSnippetsRecursively,
   Format
@@ -61,38 +58,6 @@ describe('isEcommerceUrl', () => {
   });
 });
 
-describe('selectFreeComponents', () => {
-  const light = { name: 'Hero', preview: 'light', downloadable: true, uuid: 'a' };
-  const dark = { name: 'Hero', preview: 'dark', downloadable: true, uuid: 'b' };
-
-  test('takes one record per component, preferring the light preview', () => {
-    const chosen = selectFreeComponents([light, dark]);
-    assert.equal(chosen.length, 1);
-    assert.equal(chosen[0].preview, 'light');
-  });
-
-  test('prefers light regardless of the order listed', () => {
-    const chosen = selectFreeComponents([dark, light]);
-    assert.equal(chosen.length, 1);
-    assert.equal(chosen[0].preview, 'light');
-  });
-
-  test('takes the dark record when only it is downloadable', () => {
-    const chosen = selectFreeComponents([{ ...light, downloadable: false }, dark]);
-    assert.equal(chosen.length, 1);
-    assert.equal(chosen[0].preview, 'dark');
-  });
-
-  test('ignores components that are not downloadable', () => {
-    assert.deepEqual(selectFreeComponents([{ ...light, downloadable: false }]), []);
-  });
-
-  test('keeps distinct components apart', () => {
-    const other = { name: 'Footer', preview: 'light', downloadable: true, uuid: 'c' };
-    assert.equal(selectFreeComponents([light, dark, other]).length, 2);
-  });
-});
-
 describe('retryDecision', () => {
   test('retries while attempts remain', () => {
     assert.equal(retryDecision(0, 3), 'retry');
@@ -113,48 +78,6 @@ describe('retryDecision', () => {
     // comparison was false for every page, so nothing was ever retried and each failure went
     // straight to exhausted -- silently, because that is also what a correct limit eventually says.
     assert.equal(retryDecision(0, undefined), 'exhausted');
-  });
-});
-
-describe('componentsHaveModes', () => {
-  const moded = { name: 'Hero', snippet: { name: 'html', version: 4, mode: 'light' } };
-  const modeless = { name: 'Product list', snippet: { name: 'html', version: 4, mode: null } };
-
-  test('true when a component carries a mode', () => {
-    assert.equal(componentsHaveModes([moded]), true);
-  });
-
-  test('false when every component has a null mode', () => {
-    assert.equal(componentsHaveModes([modeless, modeless]), false);
-  });
-
-  test('a component with no snippet does not make a page moded', () => {
-    // Optional chaining reads a missing snippet's mode as undefined, which is not null, so a
-    // snippetless component would drive a mode-less page through all 18 formats and collect the
-    // same six snippets three times over.
-    assert.equal(componentsHaveModes([{ name: 'Broken' }, modeless]), false);
-  });
-
-  test('false for no components at all', () => {
-    assert.equal(componentsHaveModes([]), false);
-  });
-});
-
-describe('uniqueFrameworkVersions', () => {
-  test('collapses modes, keeping one entry per framework and version', () => {
-    const formats = ['system', 'light', 'dark'].flatMap(mode => [
-      new Format('html', 4, mode),
-      new Format('vue', 3, mode)
-    ]);
-    const unique = uniqueFrameworkVersions(formats);
-
-    assert.equal(unique.length, 2);
-    assert.deepEqual(unique.map(f => `${f.framework}-v${f.version}`), ['html-v4', 'vue-v3']);
-  });
-
-  test('preserves the order given', () => {
-    const formats = [new Format('vue', 3, 'dark'), new Format('html', 4, 'dark')];
-    assert.deepEqual(uniqueFrameworkVersions(formats).map(f => f.framework), ['vue', 'html']);
   });
 });
 


### PR DESCRIPTION
TailwindPlus now gates the whole `/plus` area behind login. Every path under it answers an
unauthenticated request with a 302 to `/plus/login`, including the discovery index and the
marketing entry point the site's own homepage links to. Anonymous reads are gone, so
`--unauthenticated` cannot work and is removed.

## What changed

Removes `--unauthenticated`, the per-component format path, the Inertia partial reads it used, and
`selectFreeComponents`, `componentsHaveModes` and `uniqueFrameworkVersions`, which had no other
caller.

Its three smoke tests held every content assertion in the suite — the authenticated tests only
checked that files existed. Rather than lose that coverage, the assertions move onto authenticated
runs: component counts and descriptions on the JSON and directory basics, the 18-format sweep on
the single moded page, and a new eCommerce test for the mode-less path and its suffix-free
filenames.

The empty-URL-file and interrupt tests now need a session, because a run logs in before it reads
the URL file.

## Site monitor

CI can no longer exercise a real download at all — it holds no account, and the site serves nothing
without one. A new weekly workflow closes that gap: it logs in, runs a short download, and fails
when the site shifts underneath the downloader.

Downloaded components are licensed material and this repository is public, so the job uploads
nothing, keeps every stream out of the job log, reports only error and warning lines on failure,
and deletes the download, the logs and the credentials whatever the outcome. Credentials live in a
`site-monitor` environment; a Dependabot-triggered run cannot reach them.

It has no `pull_request` trigger, so it never runs automatically on a PR. The environment carries no
branch restriction, which leaves a manual dispatch against a branch available for changes only a
real download would catch.

## Verification

- `npm run lint`, `shellcheck test/smoke-test.sh`, `actionlint` — clean
- `npm run test:unit` — 55/55
- `bash test/smoke-test.sh` with credentials — 52/52
- `npm test` with no session or credentials, as CI runs — 22/22 passed, 11 skipped, exit 0
- The monitor's commands run verbatim: 93 URLs and 657 components discovered, 27 captured in 13s,
  count assertion passing, both report branches exercised, cleanup leaving nothing behind

BREAKING CHANGE: `--unauthenticated` is gone; every run requires an account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfv1zgkevYMSS7PHKHRLyb